### PR TITLE
mobile responsive audio player

### DIFF
--- a/src/components/blog/AudioPlayer.module.css
+++ b/src/components/blog/AudioPlayer.module.css
@@ -36,6 +36,14 @@
   gap: 0.75rem;
 }
 
+.controlsStart,
+.controlsEnd {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 0 0 auto;
+}
+
 .play {
   display: grid;
   flex: 0 0 auto;
@@ -84,11 +92,12 @@
 @media (max-width: 520px) {
   .controls {
     flex-wrap: wrap;
+    justify-content: space-between;
   }
 
   .progress {
     order: 5;
-    min-width: calc(100% - 1.5rem);
-    margin-left: 0.75rem;
+    flex: 1 1 100%;
+    min-width: 0;
   }
 }

--- a/src/components/blog/AudioPlayer.tsx
+++ b/src/components/blog/AudioPlayer.tsx
@@ -171,25 +171,28 @@ export default function AudioPlayer({ slug, title, sources }: AudioPlayerProps) 
       </div>
 
       <div className={styles.controls}>
-        <button
-          className={styles.play}
-          type="button"
-          disabled={isUnavailable}
-          aria-label={isPlaying ? 'Pause article' : 'Play article'}
-          onClick={handleTogglePlayback}
-        >
-          {isPlaying ? (
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M6 5h4v14H6zm8 0h4v14h-4z" />
-            </svg>
-          ) : (
-            <svg viewBox="0 0 24 24" aria-hidden="true">
-              <path d="M8 5v14l11-7z" />
-            </svg>
-          )}
-        </button>
+        <div className={styles.controlsStart}>
+          <button
+            className={styles.play}
+            type="button"
+            disabled={isUnavailable}
+            aria-label={isPlaying ? 'Pause article' : 'Play article'}
+            onClick={handleTogglePlayback}
+          >
+            {isPlaying ? (
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M6 5h4v14H6zm8 0h4v14h-4z" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            )}
+          </button>
 
-        <span className={styles.time}>{formatTime(currentTime)}</span>
+          <span className={styles.time}>{formatTime(currentTime)}</span>
+        </div>
+
         <label className="sr-only" htmlFor={`audio-progress-${slug}`}>
           Audio progress
         </label>
@@ -204,39 +207,42 @@ export default function AudioPlayer({ slug, title, sources }: AudioPlayerProps) 
           aria-label="Audio progress"
           onChange={(event) => handleSeek(Number(event.currentTarget.value))}
         />
-        <span className={styles.time}>{formatTime(duration)}</span>
 
-        {sources.length > 1 && (
+        <div className={styles.controlsEnd}>
+          <span className={styles.time}>{formatTime(duration)}</span>
+
+          {sources.length > 1 && (
+            <label className={styles.selectWrap}>
+              <span className="sr-only">Narration language</span>
+              <select
+                value={selectedUrl}
+                aria-label="Narration language"
+                onChange={(event) => handleLanguageChange(event.currentTarget.value)}
+              >
+                {sources.map((source) => (
+                  <option key={source.url} value={source.url}>
+                    {source.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
           <label className={styles.selectWrap}>
-            <span className="sr-only">Narration language</span>
+            <span className="sr-only">Playback speed</span>
             <select
-              value={selectedUrl}
-              aria-label="Narration language"
-              onChange={(event) => handleLanguageChange(event.currentTarget.value)}
+              value={playbackRate}
+              aria-label="Playback speed"
+              onChange={(event) => handleSpeedChange(Number(event.currentTarget.value))}
             >
-              {sources.map((source) => (
-                <option key={source.url} value={source.url}>
-                  {source.label}
+              {PLAYBACK_SPEEDS.map((speed) => (
+                <option key={speed} value={speed}>
+                  {speed}×
                 </option>
               ))}
             </select>
           </label>
-        )}
-
-        <label className={styles.selectWrap}>
-          <span className="sr-only">Playback speed</span>
-          <select
-            value={playbackRate}
-            aria-label="Playback speed"
-            onChange={(event) => handleSpeedChange(Number(event.currentTarget.value))}
-          >
-            {PLAYBACK_SPEEDS.map((speed) => (
-              <option key={speed} value={speed}>
-                {speed}×
-              </option>
-            ))}
-          </select>
-        </label>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Presentation-only changes to the blog audio player with no playback or data logic touched.
> 
> **Overview**
> Restructures the blog **AudioPlayer** control row so play/current time and duration/selects sit in separate flex groups (`controlsStart` / `controlsEnd`), which pairs with updated narrow-viewport CSS so controls wrap with **space-between** and the progress slider spans the full row.
> 
> Playback behavior is unchanged; this is markup and styling only for small screens (≤520px).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ffb920dc83a50464c01c57c2d42aeeb00c5cf7d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->